### PR TITLE
Update devular plugin  (#1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@devular/gatsby-plugin-plausible",
-  "description": "A Gatsby plugin for adding Plausible analytics to your Gatsby site",
-  "version": "0.1.8",
+  "name": "yordalina/gatsby-plugin-plausible",
+  "description": "A Gatsby plugin for adding Plausible analytics to your Gatsby website",
+  "version": "0.1.9",
   "author": "Jonathon Sherrard <jon@devular.com>, Curtis Cummings <curtis@pixelplicity.com>",
   "license": "MIT",
-  "repository": "devular/gatsby-plugin-plausible",
+  "repository": "yordalina/gatsby-plugin-plausible",
   "bugs": {
     "url": "https://github.com/devular/gatsby-plugin-plausible/issues"
   },

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -42,7 +42,7 @@ exports.onRenderBody = ({ setHeadComponents }, pluginOptions) => {
     const scriptProps = {
       async: true,
       defer: true,
-      domain: domain,
+      'data-domain': domain,
       src: proxyScript || `https://${plausibleDomain}${scriptURI}`,
     };
     if (trackAcquisition) {


### PR DESCRIPTION
* fix: domain attribute

plausible requires the attribute to be `data-domain`, not just `domain`.

* changed version - 0.1.9 to include data-domain instead of domain

* changed version - 0.1.9 to include data-domain instead of domain

---------